### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,28 +6,6 @@ on: [push]
 name: Validate
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install libasound2-dev
-
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-# Runs cargo check, test, fmt and clippy on every push for default members.
+# Runs cargo test, fmt and clippy on every push for default members.
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 
 on: [push]
@@ -57,3 +57,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,81 @@
+# Runs cargo check, test, fmt and clippy on every push for default members.
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+
+on: [push]
+
+name: Validate
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install libasound2-dev
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install libasound2-dev
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lints:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install libasound2-dev
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          ## fmt doesn't compile the crates so we can include dtrace-sys with --all
+          args: --all --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy


### PR DESCRIPTION
Since we started pushing some real meat in our PRs today let's make sure `main` is kept healthy.

I merely copied most of this from https://github.com/actions-rs/example/blob/master/.github/workflows/quickstart.yml.

Note that the target branch isn't `main`. That's because the cargo commands need at least *some* crates to complete successfully but `main` currently contains only `dtrace-sys` which is excluded. Hence this should be merged only after #9 is merged.