### PR TITLE
Simple ptrace probe that reports writes to stdout and stderr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/composer_api",
     "crates/dtrace-sys",
     "crates/test_probe",
+    "crates/ptrace_probe",
 ]
 
 # Specify a subset of member crates that compile on all supported architectures.
@@ -11,6 +12,7 @@ default-members = [
     "crates/composer_api",
     "crates/composer",
     "crates/test_probe",
+    "crates/ptrace_probe",
 ]
 
 # Explicitly set resolver due to virtual workspace, see

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -7,6 +7,8 @@ pub const DEFAULT_SERVER_ADDRESS: &str = "localhost:8888";
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Event {
     TestTick,
+    StdoutWrite { length: usize },
+    StderrWrite { length: usize },
 }
 
 pub struct Client {

--- a/crates/ptrace_probe/Cargo.toml
+++ b/crates/ptrace_probe/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 color-eyre = "0.6"
-composer = { path = "../composer" }
+composer_api = { path = "../composer_api" }
 eyre = "0.6"
 clap = { version = "4.2", features = ["derive"] }
 fork = "0.1"

--- a/crates/ptrace_probe/Cargo.toml
+++ b/crates/ptrace_probe/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 color-eyre = "0.6"
 composer = { path = "../composer" }
 eyre = "0.6"
-clap = { version = "*", features = ["derive"] }
-fork = "0.1.21"
-nix = "*"
-exec = "*"
-syscalls = "*"
+clap = { version = "4.2", features = ["derive"] }
+fork = "0.1"
+nix = "0.24"
+exec = "0.3"
+syscalls = "0.6"

--- a/crates/ptrace_probe/Cargo.toml
+++ b/crates/ptrace_probe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ptrace_probe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+color-eyre = "0.6"
+composer = { path = "../composer" }
+eyre = "0.6"
+clap = { version = "*", features = ["derive"] }
+fork = "0.1.21"
+nix = "*"
+exec = "*"
+syscalls = "*"

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer::api::{Client, Event};
+use composer_api::{Client, Event};
 use eyre::Result;
 use nix::{
     sys::{ptrace, wait::waitpid},

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
 use composer::api::{Client, Event};
-use eyre::{bail, Result};
+use eyre::Result;
 use nix::{
-    errno::Errno,
     sys::{
         ptrace::{self, Options},
         wait::waitpid,
@@ -24,34 +23,41 @@ struct Args {
 fn main() -> Result<()> {
     color_eyre::install()?;
     let args = Args::parse();
-
     let pid = Pid::from_raw(args.pid as i32);
+
+    let client = args
+        .address
+        .map(Client::new)
+        .unwrap_or(Client::try_default())?;
 
     ptrace::attach(pid)?;
     waitpid(Some(pid), None)?;
     loop {
-        // Stop on syscall invocation
-        ptrace::syscall(pid, None)?;
-        waitpid(Some(pid), None)?;
+        if let Some(event) = handle_syscall(pid)? {
+            println!("{event:?}");
+        }
+    }
+}
 
-        let registers = ptrace::getregs(pid)?;
-        let syscall: Sysno = (registers.orig_rax as i32).into();
-        print!(
-            "{syscall}({}, {}, {}, {}, {}, {})",
-            registers.rdi, registers.rsi, registers.rdx, registers.r10, registers.r8, registers.r9
-        );
+fn handle_syscall(pid: Pid) -> Result<Option<Event>, color_eyre::Report> {
+    ptrace::syscall(pid, None)?;
+    waitpid(Some(pid), None)?;
+    let registers = ptrace::getregs(pid)?;
+    let syscall: Sysno = (registers.orig_rax as i32).into();
+    let rdi = registers.rdi;
 
-        // Run the syscall
-        ptrace::syscall(pid, None)?;
-        waitpid(Some(pid), None)?;
-        match ptrace::getregs(pid) {
-            Ok(registers) => println!(" = {}", registers.rax),
-            Err(e) => {
-                println!(" = ?");
-                if e == Errno::ESRCH {
-                    bail!("Probe target exited.");
-                }
-            }
-        };
+    // At this point, the syscall is suspended, we need to call `syscall`
+    // again to actually execute it and retrieve the return value from `rax`.
+    ptrace::syscall(pid, None)?;
+    waitpid(Some(pid), None)?;
+
+    match (syscall, rdi) {
+        (Sysno::write, 1) => Ok(Some(Event::StdoutWrite {
+            length: ptrace::getregs(pid)?.rax as usize,
+        })),
+        (Sysno::write, 2) => Ok(Some(Event::StderrWrite {
+            length: ptrace::getregs(pid)?.rax as usize,
+        })),
+        _ => Ok(None),
     }
 }

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -10,10 +10,10 @@ use syscalls::Sysno;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// PID to attach to and trace
+    /// PID to attach to and trace.
     pid: u32,
 
-    /// Server address to receive events
+    /// Server address to receive events.
     address: Option<String>,
 }
 
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
     let client = args
         .address
         .map(Client::new)
-        .unwrap_or(Client::try_default())?;
+        .unwrap_or_else(Client::try_default)?;
 
     ptrace::attach(pid)?;
     waitpid(Some(pid), None)?;

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -22,10 +22,10 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let pid = Pid::from_raw(args.pid as i32);
 
-    let client = args
-        .address
-        .map(Client::new)
-        .unwrap_or_else(Client::try_default)?;
+    let client = match args.address {
+        Some(address) => Client::new(address),
+        None => Client::try_default(),
+    }?;
 
     ptrace::attach(pid)?;
     waitpid(Some(pid), None)?;

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -1,0 +1,57 @@
+use clap::Parser;
+use composer::api::{Client, Event};
+use eyre::{bail, Result};
+use nix::{
+    errno::Errno,
+    sys::{
+        ptrace::{self, Options},
+        wait::waitpid,
+    },
+    unistd::Pid,
+};
+use syscalls::Sysno;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// PID to attach to and trace
+    pid: u32,
+
+    /// Server address to receive events
+    address: Option<String>,
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let args = Args::parse();
+
+    let pid = Pid::from_raw(args.pid as i32);
+
+    ptrace::attach(pid)?;
+    waitpid(Some(pid), None)?;
+    loop {
+        // Stop on syscall invocation
+        ptrace::syscall(pid, None)?;
+        waitpid(Some(pid), None)?;
+
+        let registers = ptrace::getregs(pid)?;
+        let syscall: Sysno = (registers.orig_rax as i32).into();
+        print!(
+            "{syscall}({}, {}, {}, {}, {}, {})",
+            registers.rdi, registers.rsi, registers.rdx, registers.r10, registers.r8, registers.r9
+        );
+
+        // Run the syscall
+        ptrace::syscall(pid, None)?;
+        waitpid(Some(pid), None)?;
+        match ptrace::getregs(pid) {
+            Ok(registers) => println!(" = {}", registers.rax),
+            Err(e) => {
+                println!(" = ?");
+                if e == Errno::ESRCH {
+                    bail!("Probe target exited.");
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10514864/234004931-4214e6b6-d174-47b7-aa8c-6d5b9e7864f0.png)

I decided to go with the `stdout` and `stderr` writes as an example as they have an easy to interpret first argument and return value. It's probably not ideal to go much further with `ptrace` because of the difficulty of tracing a multithreaded program that forked before attaching the probe. This probe simply traces the `main` thread.

Oh, it also should be run with `root` permissions; it's difficult to safely allow ptrace to be used by a non-root user.