### PR TITLE
Log probe 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/test_probe",
     "crates/tick_probe",
     "crates/ptrace_probe",
+    "crates/log_probe",
 ]
 
 # Specify a subset of member crates that compile on all supported architectures.
@@ -16,6 +17,7 @@ default-members = [
     "crates/test_probe",
     "crates/tick_probe",
     "crates/ptrace_probe",
+    "crates/log_probe",
 ]
 
 # Explicitly set resolver due to virtual workspace, see

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -56,6 +56,8 @@ fn handle_datagram(
 
         // TODO(Matej): add different sounds for these, and vary some their quality based on length.
         Event::StderrWrite { length: _ } | Event::StdoutWrite { length: _ } => Sample::Click,
+        // TODO(Pablo): Play a sound that scales with the number of reports.
+        Event::LogStats(_) => todo!(),
     };
     jukebox.play(output_stream, sample)?;
 

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -2,9 +2,12 @@
 
 use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
-use std::net::{
-    SocketAddr::{V4, V6},
-    ToSocketAddrs, UdpSocket,
+use std::{
+    net::{
+        SocketAddr::{V4, V6},
+        ToSocketAddrs, UdpSocket,
+    },
+    time::Duration,
 };
 
 pub const DEFAULT_SERVER_ADDRESS: &str = "localhost:8888";
@@ -14,6 +17,20 @@ pub enum Event {
     TestTick,
     StdoutWrite { length: usize },
     StderrWrite { length: usize },
+    LogStats(LogStats),
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct LogStats {
+    // Duration covered by this report.
+    pub span: Duration,
+
+    // Number of records of each kind.
+    pub error_records: u32,
+    pub warn_records: u32,
+    pub info_records: u32,
+    pub debug_records: u32,
+    pub trace_records: u32,
 }
 
 pub struct Client {

--- a/crates/log_probe/Cargo.toml
+++ b/crates/log_probe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "log_probe"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"
+composer_api = { path = "../composer_api" }
+thiserror = "1.0.40"

--- a/crates/log_probe/Cargo.toml
+++ b/crates/log_probe/Cargo.toml
@@ -3,9 +3,7 @@ name = "log_probe"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 log = "0.4"
 composer_api = { path = "../composer_api" }
-thiserror = "1.0.40"
+thiserror = "1.0"

--- a/crates/log_probe/Cargo.toml
+++ b/crates/log_probe/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-log = "0.4"
+log = {version = "0.4", features = ["std"] }
 composer_api = { path = "../composer_api" }
 thiserror = "1.0"
+
+[[example]]
+name = "warn_and_error_loop"
+path = "examples/warn_and_error_loop.rs"

--- a/crates/log_probe/examples/warn_and_error_loop.rs
+++ b/crates/log_probe/examples/warn_and_error_loop.rs
@@ -1,0 +1,18 @@
+use log::{error, warn};
+use std::time::Duration;
+
+fn main() {
+    log::set_boxed_logger(Box::new(
+        log_probe::LogProbe::new(None, Duration::from_millis(500)).unwrap(),
+    ))
+    .unwrap();
+    log::set_max_level(log::LevelFilter::Trace);
+
+    loop {
+        std::thread::sleep(Duration::from_millis(100));
+        error!("Oops, something bad happened");
+        warn!("Oops, something not so bad happened");
+        std::thread::sleep(Duration::from_millis(100));
+        warn!("Oops, something not so bad happened");
+    }
+}

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -1,0 +1,126 @@
+use composer_api::{self, Client, LogStats};
+use log::{self, Level};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{channel, Sender},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LogProbeError {
+    #[error("Network error: {0}")]
+    NetworkError(String),
+}
+
+pub struct LogProbe {
+    tx: Sender<AggregatorMessage>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Drop for LogProbe {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
+
+enum AggregatorMessage {
+    AddRecord(Level),
+    Tick,
+}
+
+impl LogProbe {
+    pub fn new(
+        server_address: Option<String>,
+        report_frequency: Duration,
+    ) -> Result<Self, LogProbeError> {
+        let shutdown = Arc::<AtomicBool>::default();
+        let client = if let Some(address) = server_address {
+            Client::new(address)
+        } else {
+            Client::try_default()
+        }
+        .map_err(|e| LogProbeError::NetworkError(format!("{e}")))?;
+
+        let (tx, rx) = channel::<AggregatorMessage>();
+        spawn_aggregator_thread(rx, client, shutdown.clone());
+        spawn_tick_thread(tx.clone(), shutdown.clone(), report_frequency);
+
+        Ok(Self { tx, shutdown })
+    }
+}
+
+fn spawn_tick_thread(
+    tx: Sender<AggregatorMessage>,
+    shutdown: Arc<AtomicBool>,
+    report_frequency: Duration,
+) {
+    std::thread::spawn(move || {
+        let start = Instant::now();
+        for deadline in (0..).map(|i| start + i * report_frequency) {
+            if let Err(e) = tx.send(AggregatorMessage::Tick) {
+                eprintln!("Failed to communicate with aggregator thread.")
+            }
+
+            if shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+
+            std::thread::sleep(deadline - Instant::now());
+        }
+    });
+}
+
+fn spawn_aggregator_thread(
+    rx: std::sync::mpsc::Receiver<AggregatorMessage>,
+    client: Client,
+    shutdown: Arc<AtomicBool>,
+) {
+    let mut log_stats = LogStats::default();
+    let mut report_start = Instant::now();
+
+    std::thread::spawn(move || {
+        for message in rx {
+            if shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+
+            match message {
+                AggregatorMessage::AddRecord(record) => add_record(&mut log_stats, record),
+                AggregatorMessage::Tick => {
+                    log_stats.span = report_start.elapsed();
+                    if let Err(err) = client.send(&composer_api::Event::LogStats(log_stats)) {
+                        eprintln!("Could not send event {:?}", err)
+                    };
+                    log_stats = Default::default();
+                    report_start = Instant::now();
+                },
+            }
+        }
+    });
+}
+
+fn add_record(log_stats: &mut LogStats, record_level: Level) {
+    match record_level {
+        Level::Error => log_stats.error_records += 1,
+        Level::Warn => log_stats.warn_records += 1,
+        Level::Info => log_stats.info_records += 1,
+        Level::Debug => log_stats.debug_records += 1,
+        Level::Trace => log_stats.trace_records += 1,
+    }
+}
+
+// impl log::Log for LogProbe {
+//     fn enabled(&self, metadata: &log::Metadata) -> bool {
+//         metadata.level() <= Level::Info
+//     }
+
+//     fn log(&self, record: &log::Record) {
+//         todo!()
+//     }
+
+//     fn flush(&self) {}
+// }


### PR DESCRIPTION
Not very clean, but works as a proof of concept :).

Here's a sample program that I used to test it:

```rust
use std::time::Duration;

use log::{error, warn};

fn main() {
    log::set_boxed_logger(Box::new(
        log_probe::LogProbe::new(None, Duration::from_millis(500)).unwrap(),
    ))
    .unwrap();
    log::set_max_level(log::LevelFilter::Trace);

    loop {
        std::thread::sleep(Duration::from_millis(100));
        error!("Oops, something bad happened");
        warn!("Oops, something not so bad happened");
        std::thread::sleep(Duration::from_millis(100));
        warn!("Oops, something not so bad happened");
    }
}
```

and here's the output on the server side:

```
Received an event (36 bytes): LogStats(LogStats { span: 500.089013ms, error_records: 2, warn_records: 5, info_records: 0, debug_records: 0, trace_records: 0 })
Received an event (36 bytes): LogStats(LogStats { span: 499.889905ms, error_records: 3, warn_records: 5, info_records: 0, debug_records: 0, trace_records: 0 })
Received an event (36 bytes): LogStats(LogStats { span: 500.194193ms, error_records: 2, warn_records: 5, info_records: 0, debug_records: 0, trace_records: 0 })
Received an event (36 bytes): LogStats(LogStats { span: 499.49606ms, error_records: 3, warn_records: 5, info_records: 0, debug_records: 0, trace_records: 0 })
// ...
```