### PR TITLE
Use `clap` in test probe and allow custom address for composer

### DIFF
--- a/crates/composer/Cargo.toml
+++ b/crates/composer/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1"
+clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
 composer_api = { path = "../composer_api" }
 eyre = "0.6"

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
 use crate::jukebox::{Jukebox, Sample};
+use clap::Parser;
 use composer_api::{Event, DEFAULT_SERVER_ADDRESS};
 use eyre::{Context, Result};
 use rodio::{OutputStream, OutputStreamHandle};
@@ -8,10 +9,19 @@ use std::net::UdpSocket;
 
 mod jukebox;
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// the address to listen on for incoming events
+    address: Option<String>,
+}
+
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let socket = UdpSocket::bind(DEFAULT_SERVER_ADDRESS)?;
+    let args = Args::parse();
+
+    let socket = UdpSocket::bind(args.address.as_deref().unwrap_or(DEFAULT_SERVER_ADDRESS))?;
     println!("Listening on {}", socket.local_addr()?);
 
     let (_stream, stream_handle) = OutputStream::try_default()?;

--- a/crates/test_probe/Cargo.toml
+++ b/crates/test_probe/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
 composer_api = { path = "../composer_api" }
 eyre = "0.6"

--- a/crates/test_probe/src/main.rs
+++ b/crates/test_probe/src/main.rs
@@ -1,18 +1,25 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
+use clap::Parser;
 use composer_api::{Client, Event};
 use eyre::Result;
-use std::{env, thread, time::Duration};
+use std::{thread, time::Duration};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Server address to receive events.
+    address: Option<String>,
+}
 
 fn main() -> Result<()> {
     color_eyre::install()?;
 
-    // Get server address, if given
-    let args: Vec<String> = env::args().collect();
-    let client = match args.get(1) {
-        Some(address) => Client::new(address)?,
-        None => Client::try_default()?,
-    };
+    let args = Args::parse();
+    let client = match args.address {
+        Some(address) => Client::new(address),
+        None => Client::try_default(),
+    }?;
 
     let event = Event::TestTick;
 


### PR DESCRIPTION
Two simple changes:

The first commit closes #16.

The second allows us to pass a custom address for the composer to listen on. That comes in handy when one wants to receive events over network.

