### PR TITLE
Use the same family for local as for remote address

### DIFF
--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -2,7 +2,10 @@
 
 use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
-use std::net::{ToSocketAddrs, UdpSocket};
+use std::net::{
+    SocketAddr::{V4, V6},
+    ToSocketAddrs, UdpSocket,
+};
 
 pub const DEFAULT_SERVER_ADDRESS: &str = "localhost:8888";
 
@@ -44,12 +47,9 @@ impl Client {
             .ok_or(eyre!("can't resolve server address"))?;
 
         // Set the address and port to 0 to let the OS choose unoccupied values for us
-        if server_address.is_ipv4() {
-            Ok("0.0.0.0:0")
-        } else if server_address.is_ipv6() {
-            Ok(":::0")
-        } else {
-            Err(eyre!("not an IP address"))
+        match server_address {
+            V4(_) => Ok("0.0.0.0:0"),
+            V6(_) => Ok(":::0"),
         }
     }
 }

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
-use eyre::Result;
+use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 use std::net::{ToSocketAddrs, UdpSocket};
 
@@ -23,7 +23,7 @@ impl Client {
     }
 
     pub fn new(server_address: impl ToSocketAddrs) -> Result<Self> {
-        let socket = UdpSocket::bind("localhost:0")?;
+        let socket = UdpSocket::bind(Self::get_local_address(&server_address)?)?;
         socket.connect(server_address)?;
 
         Ok(Self { socket })
@@ -33,5 +33,38 @@ impl Client {
         let data = bincode::serialize(event)?;
         self.socket.send(&data)?;
         Ok(())
+    }
+
+    /// Given a server address, returns a wildcard address of the same family (IPv4 or 6)
+    /// that can be used to bind a socket for connecting to the server.
+    fn get_local_address(server_address: &impl ToSocketAddrs) -> Result<&'static str> {
+        let server_address = server_address
+            .to_socket_addrs()?
+            .next()
+            .ok_or(eyre!("can't resolve server address"))?;
+
+        // Set the address and port to 0 to let the OS choose unoccupied values for us
+        if server_address.is_ipv4() {
+            Ok("0.0.0.0:0")
+        } else if server_address.is_ipv6() {
+            Ok(":::0")
+        } else {
+            Err(eyre!("not an IP address"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn returns_ipv4_wildcard_for_ipv4_address() {
+        assert_eq!(Client::get_local_address(&"8.8.8.8:8888").unwrap(), "0.0.0.0:0");
+    }
+
+    #[test]
+    fn returns_ipv6_wildcard_for_ipv6_address() {
+        assert_eq!(Client::get_local_address(&"8::8:8888").unwrap(), ":::0");
     }
 }


### PR DESCRIPTION
To construct a socket it must be first bound to a local address and only then it can connect to a remote address.

For the connection to succeed both addresses must be of the same family (IPv4 or 6).

When constructing the client first parse the given server address to determine its family and then bind to a wildcard address of the same family.

fixes #27