### PR TITLE
Fix formatting, CI: run rustfmt on nightly toolchain

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           command: test
 
-  lints:
-    name: Lint
+  clippy:
+    name: Run Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Install native dependencies
@@ -44,7 +44,28 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: rustfmt, clippy
+          components: clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D warnings
+
+  format:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -52,9 +73,3 @@ jobs:
           command: fmt
           ## fmt doesn't compile the crates so we can include dtrace-sys with --all
           args: --all --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings

--- a/crates/dtrace/src/lib.rs
+++ b/crates/dtrace/src/lib.rs
@@ -67,13 +67,7 @@ impl ProbeData {
         let module_name = c_char_to_string(desc.dtpd_mod.as_ptr());
         let name = c_char_to_string(desc.dtpd_name.as_ptr());
         let function_name = c_char_to_string(desc.dtpd_func.as_ptr());
-        Self {
-            cpu_id,
-            provider_name,
-            module_name,
-            function_name,
-            name,
-        }
+        Self { cpu_id, provider_name, module_name, function_name, name }
     }
 }
 
@@ -122,10 +116,7 @@ impl DTrace {
             return Err(Error::InitializationError(c_char_to_string(message_raw)));
         }
 
-        Ok(Self {
-            inner: dtrace,
-            probes: Vec::default(),
-        })
+        Ok(Self { inner: dtrace, probes: Vec::default() })
     }
 
     /// Compiles a D program and starts collecting probe data.


### PR DESCRIPTION
### Fix formatting

### CI: run rustfmt on nightly toolchain

I forgot that some of the options we use are nightly-only. The warnings are not printed on success run, but in failed one they are: https://github.com/tonarino/acoustic_profiler/actions/runs/4807252551/jobs/8555777744

Tests and clippy still use the stable toolchain.