### PR TITLE
Use fundsp network to play up to 20 samples at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 **/*.rs.bk
 
 .vscode
+.DS_Store

--- a/crates/composer/Cargo.toml
+++ b/crates/composer/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 bincode = "1"
 clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
+cpal = "0.15"
 composer_api = { path = "../composer_api" }
 eyre = "0.6"
+fundsp = "0.13"
 rodio = { version = "0.17", features = ["symphonia-wav"] }

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -44,7 +44,7 @@ fn handle_datagram(socket: &UdpSocket, sound_controller: &mut SoundController) -
 
     let _event: Event = bincode::deserialize(&buf[..number_of_bytes])?;
 
-    sound_controller.increment_hz();
+    sound_controller.play_click();
 
     Ok(number_of_bytes)
 }

--- a/crates/composer/src/sound.rs
+++ b/crates/composer/src/sound.rs
@@ -1,0 +1,58 @@
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    BufferSize, SampleRate, StreamConfig,
+};
+use eyre::Result;
+use fundsp::hacker::*;
+
+pub struct SoundController {
+    _stream: cpal::Stream,
+    custom_osc_hz: Shared<f64>,
+}
+
+impl SoundController {
+    pub fn new() -> Result<Self> {
+        let host = cpal::default_host();
+
+        let device = host.default_output_device().expect("Failed to find a default output device");
+
+        // TODO(bschwind) - Hardcode this for now, but let's extract these param
+        //                  from device.default_output_config later.
+        let stream_config = StreamConfig {
+            channels: 1,
+            sample_rate: SampleRate(48_000),
+            buffer_size: BufferSize::Default,
+        };
+
+        let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
+
+        let custom_osc_hz = shared(0.0f64);
+        let custom_osc = var(&custom_osc_hz) >> sine();
+
+        let mut c = 0.3
+            * (custom_osc
+                + organ_hz(midi_hz(57.0))
+                + organ_hz(midi_hz(61.0))
+                + organ_hz(midi_hz(64.0)));
+
+        let stream = device.build_output_stream(
+            &stream_config,
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                for sample in data {
+                    *sample = c.get_mono() as f32;
+                }
+            },
+            err_fn,
+            None,
+        )?;
+
+        stream.play()?;
+
+        Ok(Self { _stream: stream, custom_osc_hz })
+    }
+
+    pub fn increment_hz(&mut self) {
+        let current_val = self.custom_osc_hz.value();
+        self.custom_osc_hz.set_value(current_val + 5.0);
+    }
+}

--- a/crates/composer/src/sound.rs
+++ b/crates/composer/src/sound.rs
@@ -7,7 +7,7 @@ use fundsp::hacker::*;
 
 pub struct SoundController {
     _stream: cpal::Stream,
-    custom_osc_hz: Shared<f64>,
+    custom_organ_hz: Shared<f64>,
 }
 
 impl SoundController {
@@ -26,8 +26,10 @@ impl SoundController {
 
         let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
 
-        let custom_osc_hz = shared(0.0f64);
-        let custom_osc = var(&custom_osc_hz) >> sine();
+        let custom_organ_hz = shared(0.0f64);
+        let custom_osc = var_fn(&custom_organ_hz, |hz| hz.clamp(0.0, 1000.0))
+            >> organ()
+            >> chorus(0, 0.0, 0.1, 0.1);
 
         let mut dsp_graph = 0.3
             * (custom_osc
@@ -48,11 +50,11 @@ impl SoundController {
 
         stream.play()?;
 
-        Ok(Self { _stream: stream, custom_osc_hz })
+        Ok(Self { _stream: stream, custom_organ_hz })
     }
 
     pub fn increment_hz(&mut self) {
-        let current_val = self.custom_osc_hz.value();
-        self.custom_osc_hz.set_value(current_val + 5.0);
+        let current_val = self.custom_organ_hz.value();
+        self.custom_organ_hz.set_value(current_val + 5.0);
     }
 }

--- a/crates/composer/src/sound.rs
+++ b/crates/composer/src/sound.rs
@@ -29,7 +29,7 @@ impl SoundController {
         let custom_osc_hz = shared(0.0f64);
         let custom_osc = var(&custom_osc_hz) >> sine();
 
-        let mut c = 0.3
+        let mut dsp_graph = 0.3
             * (custom_osc
                 + organ_hz(midi_hz(57.0))
                 + organ_hz(midi_hz(61.0))
@@ -39,7 +39,7 @@ impl SoundController {
             &stream_config,
             move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
                 for sample in data {
-                    *sample = c.get_mono() as f32;
+                    *sample = dsp_graph.get_mono() as f32;
                 }
             },
             err_fn,


### PR DESCRIPTION
@bschwind very dirty example, but it works! You can focus only on the [last commit](https://github.com/tonarino/acoustic_profiler/pull/35/commits/a252b47324acac90e689007b20fc3ce056cf22a2) which builds on top of #33. The rest is your branch but rebased on `main` as I needed `tick_probe` for testing this out.

The main caveat is that the mixer is built statically. It's type is something like
```
An<Binop<f64, FrameAdd<UInt<UTerm, B1>, f64>, Binop<f64, FrameAdd<UInt<UTerm, B1>, f64>, Binop<f64, FrameAdd<..., ...>, ..., ...>, ...>, ...>>
```

Not only such code is ugly and fragile (number of `+ pass()` needs to be kept in sync with `NUM_SLOTS`) but it also seems that compilation time grows very quickly with the number of slots. (https://github.com/rust-lang/rust/issues/99188 may be to blame)

I'd hope that we could adapt this to using `AudioUnits` instead of `AudioNodes` to construct the mixer, but I haven't yet figured out how.

