### PR TITLE
Drive audio directly using cpal, position sounds precisely within callbacks

### DIFF
--- a/crates/composer/Cargo.toml
+++ b/crates/composer/Cargo.toml
@@ -8,5 +8,6 @@ bincode = "1"
 clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
 composer_api = { path = "../composer_api" }
+cpal = "0.15"
 eyre = "0.6"
 rodio = { version = "0.17", features = ["symphonia-wav"] }

--- a/crates/composer/src/audio_output.rs
+++ b/crates/composer/src/audio_output.rs
@@ -23,6 +23,10 @@ pub(crate) struct AudioOutput {
     _stream: cpal::Stream,
 }
 
+/// Abstraction to actually produce sound using the [AudioOutput::play()] method.
+/// Uses `cpal` and `rodio` behind the curtains. Great care is taken to position played samples
+/// precisely in time so that sound superposition works well even at high frequencies.
+/// Playback stops when this struct is dropped.
 impl AudioOutput {
     pub(crate) fn new(play_delay: Duration) -> Result<Self> {
         let cpal_device = cpal::default_host()

--- a/crates/composer/src/jukebox.rs
+++ b/crates/composer/src/jukebox.rs
@@ -1,7 +1,8 @@
+use crate::sound::AudioOutput;
 use eyre::{Context, Result};
 use rodio::{
     source::{Buffered, SamplesConverter},
-    Decoder, OutputStreamHandle, Source,
+    Decoder, Source,
 };
 use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
 
@@ -48,15 +49,12 @@ impl Jukebox {
         Ok(Self { samples })
     }
 
-    pub(crate) fn play(&self, output_stream: &OutputStreamHandle, sample: Sample) -> Result<()> {
+    pub(crate) fn play(&self, audio_output: &AudioOutput, sample: Sample) {
         let buffer = self
             .samples
             .get(&sample)
             .expect("programmer error, all possible samples should be loaded");
 
-        output_stream
-            .play_raw(buffer.clone())
-            .with_context(|| format!("playing sample {sample:?}"))?;
-        Ok(())
+        audio_output.play(buffer.clone());
     }
 }

--- a/crates/composer/src/jukebox.rs
+++ b/crates/composer/src/jukebox.rs
@@ -1,4 +1,4 @@
-use crate::sound::AudioOutput;
+use crate::audio_output::AudioOutput;
 use eyre::{Context, Result};
 use rodio::{
     source::{Buffered, SamplesConverter},

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -1,8 +1,8 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
 use crate::{
+    audio_output::AudioOutput,
     jukebox::{Jukebox, Sample},
-    sound::AudioOutput,
 };
 use clap::Parser;
 use composer_api::{Event, DEFAULT_SERVER_ADDRESS};
@@ -12,8 +12,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod audio_output;
 mod jukebox;
-mod sound;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -1,16 +1,19 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
-use crate::jukebox::{Jukebox, Sample};
+use crate::{
+    jukebox::{Jukebox, Sample},
+    sound::AudioOutput,
+};
 use clap::Parser;
 use composer_api::{Event, DEFAULT_SERVER_ADDRESS};
 use eyre::{Context, Result};
-use rodio::{OutputStream, OutputStreamHandle};
 use std::{
     net::UdpSocket,
     time::{Duration, Instant},
 };
 
 mod jukebox;
+mod sound;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -27,12 +30,12 @@ fn main() -> Result<()> {
     let socket = UdpSocket::bind(args.address.as_deref().unwrap_or(DEFAULT_SERVER_ADDRESS))?;
     println!("Listening on {}", socket.local_addr()?);
 
-    let (_stream, stream_handle) = OutputStream::try_default()?;
+    let audio_output = AudioOutput::new()?;
 
     let jukebox = Jukebox::new().context("creating jukebox")?;
     let mut stats = Stats { since: Instant::now(), events: 0, total_bytes: 0 };
     loop {
-        match handle_datagram(&socket, &stream_handle, &jukebox) {
+        match handle_datagram(&socket, &audio_output, &jukebox) {
             Ok(bytes_received) => stats.record_event(bytes_received),
             Err(err) => eprintln!("Could not process datagram. Ignoring and continuing. {:?}", err),
         }
@@ -42,7 +45,7 @@ fn main() -> Result<()> {
 /// Block until next datagram is received and handle it. Returns its size in bytes.
 fn handle_datagram(
     socket: &UdpSocket,
-    output_stream: &OutputStreamHandle,
+    audio_output: &AudioOutput,
     jukebox: &Jukebox,
 ) -> Result<usize> {
     // Size up to max normal network packet size
@@ -57,7 +60,7 @@ fn handle_datagram(
         // TODO(Matej): add different sounds for these, and vary some their quality based on length.
         Event::StderrWrite { length: _ } | Event::StdoutWrite { length: _ } => Sample::Click,
     };
-    jukebox.play(output_stream, sample)?;
+    jukebox.play(audio_output, sample);
 
     Ok(number_of_bytes)
 }

--- a/crates/composer/src/sound.rs
+++ b/crates/composer/src/sound.rs
@@ -1,26 +1,30 @@
 use cpal::{
     traits::{DeviceTrait, HostTrait},
-    SampleFormat,
+    OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, StreamInstant,
 };
 use eyre::{bail, eyre, Result};
-use rodio::{dynamic_mixer::DynamicMixerController, Source};
+use rodio::{
+    dynamic_mixer::{DynamicMixer, DynamicMixerController},
+    Source,
+};
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},
+        mpsc::{channel, Receiver, Sender, TryRecvError},
         Arc,
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 pub(crate) struct AudioOutput {
-    mixer_controller: Arc<DynamicMixerController<f32>>,
-    /// UNIX timestamp in nanoseconds, as an atomic variable.
-    last_callback_timestamp_ns: Arc<AtomicU64>,
+    source_tx: Sender<TimedSource>,
+    play_delay: Duration,
+    too_early_plays: Arc<AtomicU64>,
     _stream: cpal::Stream,
 }
 
 impl AudioOutput {
-    pub(crate) fn new() -> Result<Self> {
+    pub(crate) fn new(play_delay: Duration) -> Result<Self> {
         let cpal_device = cpal::default_host()
             .default_output_device()
             .ok_or_else(|| eyre!("no cpal audio output device found"))?;
@@ -36,48 +40,137 @@ impl AudioOutput {
             bail!("Only F32 sample format supported for now.");
         }
 
-        let (mixer_controller, mut mixer) =
+        let (mixer_controller, mixer) =
             rodio::dynamic_mixer::mixer::<f32>(stream_config.channels, stream_config.sample_rate.0);
 
-        let last_callback_timestamp_ns = Arc::new(AtomicU64::new(0));
+        let (source_tx, source_rx) = channel();
 
-        let last_callback_timestamp_ns_alias = Arc::clone(&last_callback_timestamp_ns);
+        let too_early_plays = Arc::default();
+
+        // The mixer_controller can be shared between threads, but we want to precisely control
+        // when we add new sources w.r.t. the audio callback, so we move it to the audio thread and
+        // use a mpsc channel to send new sources to the audio thread.
+        let mut audio_callback =
+            AudioCallback::new(mixer_controller, mixer, source_rx, &too_early_plays);
         let _stream = cpal_device.build_output_stream::<f32, _, _>(
             &stream_config,
-            move |data_out, _info| {
-                // println!("data_callback: date_out.len(): {}, info: {_info:?}.", data_out.len());
-
-                // TODO(Matej): can we use timestamps in _info instead?
-                // TODO(Matej): specify less strict ordering (in all places for this atomic var)
-                last_callback_timestamp_ns_alias.store(current_timestamp_ns(), Ordering::SeqCst);
-
-                data_out.iter_mut().for_each(|d| *d = mixer.next().unwrap_or(0f32))
-            },
+            move |data_out, info| audio_callback.fill_data(data_out, info),
             |err| eprintln!("Got cpal stream error callback: {err}."),
             None,
         )?;
 
-        Ok(Self { mixer_controller, last_callback_timestamp_ns, _stream })
+        Ok(Self { source_tx, play_delay, too_early_plays, _stream })
     }
 
     pub(crate) fn play<S: Source<Item = f32> + Send + 'static>(&self, source: S) {
-        let ns_since_last_callback = current_timestamp_ns()
-            .saturating_sub(self.last_callback_timestamp_ns.load(Ordering::SeqCst));
-        // println!("ns_since_last_callback: {ns_since_last_callback:>9}.",);
+        // TODO(Matej): use timestamp from the event itself once we have it.
+        let play_at_timestamp = current_timestamp() + self.play_delay;
 
-        // We assume that cpal's audio callbacks come at a steady rate, so we delay sounds to play
-        // by the time since last audio callback, so that it gets played at correct offset during
-        // the *next* callback. This is needed to accurately position sounds (sub buffer level).
-        // https://github.com/tonarino/acoustic_profiler/issues/19#issuecomment-1522348735
-        self.mixer_controller.add(source.delay(Duration::from_nanos(ns_since_last_callback)));
+        // TODO(Matej): we are in fact double-boxing because DynamicMixerController internally adds
+        // another box. But we need a sized type to send it through threads. We could make this
+        // method non-generic, but that would be less flexible, so just accept it for now.
+        let source = Box::new(source);
+
+        self.source_tx
+            .send(TimedSource { source, play_at_timestamp })
+            .expect("source receiver should be still alive");
+    }
+
+    /// Get "too early plays" counter since the last call of this method.
+    pub(crate) fn fetch_too_early_plays(&self) -> u64 {
+        self.too_early_plays.swap(0, Ordering::SeqCst)
     }
 }
 
-fn current_timestamp_ns() -> u64 {
-    let duration_since_epoch =
-        SystemTime::now().duration_since(UNIX_EPOCH).expect("Unable to get current UNIX time");
-    duration_since_epoch
-        .as_nanos()
-        .try_into()
-        .expect("Cannot convert current UNIX timestamp in nanoseconds into u64")
+/// An f32 [rodio::source::Source] with UNIX timestamp of desired play time attached.
+struct TimedSource {
+    source: Box<dyn Source<Item = f32> + Send + 'static>,
+    play_at_timestamp: Duration,
+}
+
+/// A sort of manual implementation of the closure used as cpal audio data callback, for tidiness.
+struct AudioCallback {
+    mixer_controller: Arc<DynamicMixerController<f32>>,
+    mixer: DynamicMixer<f32>,
+    source_rx: Receiver<TimedSource>,
+    too_early_plays: Arc<AtomicU64>,
+    stream_start: Option<StreamStart>,
+}
+
+impl AudioCallback {
+    fn new(
+        mixer_controller: Arc<DynamicMixerController<f32>>,
+        mixer: DynamicMixer<f32>,
+        source_rx: Receiver<TimedSource>,
+        too_early_plays: &Arc<AtomicU64>,
+    ) -> Self {
+        let too_early_plays = Arc::clone(too_early_plays);
+        Self { mixer_controller, mixer, source_rx, too_early_plays, stream_start: None }
+    }
+
+    fn fill_data(&mut self, data_out: &mut [f32], info: &OutputCallbackInfo) {
+        let stream_timestamp = info.timestamp();
+        let stream_start =
+            self.stream_start.get_or_insert_with(|| StreamStart::new(stream_timestamp));
+
+        // At least on Linux ALSA, cpal gives very strange stream timestamp on very first call.
+        if stream_start.callback > stream_timestamp.callback {
+            eprintln!("cpal's stream timestamp jumped backwards, resetting stream start.");
+            *stream_start = StreamStart::new(stream_timestamp);
+        }
+
+        // UNIX timestamp of when the buffer filled during this call will be actually played.
+        let buffer_playback_timestamp = stream_start.realtime
+            + (stream_timestamp.playback.duration_since(&stream_start.callback).expect(
+                "current playback timestamp should be larger than start callback timestamp",
+            ));
+
+        // Add possible new sources to the list
+        loop {
+            match self.source_rx.try_recv() {
+                Ok(timed_source) => {
+                    let delay = timed_source
+                        .play_at_timestamp
+                        .checked_sub(buffer_playback_timestamp)
+                        .unwrap_or_else(|| {
+                            self.too_early_plays.fetch_add(1, Ordering::SeqCst);
+                            Duration::ZERO
+                        });
+                    self.mixer_controller.add(timed_source.source.delay(delay));
+                },
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => panic!("source sender should be still alive"),
+            }
+        }
+
+        data_out.iter_mut().for_each(|d| *d = self.mixer.next().unwrap_or(0f32))
+    }
+}
+
+/// An utility struct that anchors stream's internal timestamp to real world UNIX timestamp.
+struct StreamStart {
+    /// Timestamp of the start of stream _playback_ as the `Duration` since the UNIX epoch.
+    realtime: Duration,
+    /// Internal cpal's callback timestamp of stream start.
+    callback: StreamInstant,
+}
+
+impl StreamStart {
+    fn new(stream_timestamp: OutputStreamTimestamp) -> Self {
+        let realtime = current_timestamp();
+        println!(
+            "Audio stream starting at {realtime:?} UNIX timestamp, callback timestamp {:?}, \
+            playback timestamp delayed by {:?} after callback.",
+            stream_timestamp.callback,
+            stream_timestamp.playback.duration_since(&stream_timestamp.callback)
+        );
+
+        // We record _callback_ timestamp for the purposes of fixing playback in real time.
+        Self { realtime, callback: stream_timestamp.callback }
+    }
+}
+
+// Get current timestamp as the `Duration` since the UNIX epoch.
+fn current_timestamp() -> Duration {
+    SystemTime::now().duration_since(UNIX_EPOCH).expect("Unable to get current UNIX time")
 }

--- a/crates/composer/src/sound.rs
+++ b/crates/composer/src/sound.rs
@@ -1,0 +1,83 @@
+use cpal::{
+    traits::{DeviceTrait, HostTrait},
+    SampleFormat,
+};
+use eyre::{bail, eyre, Result};
+use rodio::{dynamic_mixer::DynamicMixerController, Source};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+pub(crate) struct AudioOutput {
+    mixer_controller: Arc<DynamicMixerController<f32>>,
+    /// UNIX timestamp in nanoseconds, as an atomic variable.
+    last_callback_timestamp_ns: Arc<AtomicU64>,
+    _stream: cpal::Stream,
+}
+
+impl AudioOutput {
+    pub(crate) fn new() -> Result<Self> {
+        let cpal_device = cpal::default_host()
+            .default_output_device()
+            .ok_or_else(|| eyre!("no cpal audio output device found"))?;
+        let supported_config = cpal_device.default_output_config()?;
+        let stream_config = supported_config.config();
+        println!(
+            "Using audio device '{}', supported config {:?}, stream config {:?}.",
+            cpal_device.name()?,
+            supported_config,
+            stream_config,
+        );
+        if supported_config.sample_format() != SampleFormat::F32 {
+            bail!("Only F32 sample format supported for now.");
+        }
+
+        let (mixer_controller, mut mixer) =
+            rodio::dynamic_mixer::mixer::<f32>(stream_config.channels, stream_config.sample_rate.0);
+
+        let last_callback_timestamp_ns = Arc::new(AtomicU64::new(0));
+
+        let last_callback_timestamp_ns_alias = Arc::clone(&last_callback_timestamp_ns);
+        let _stream = cpal_device.build_output_stream::<f32, _, _>(
+            &stream_config,
+            move |data_out, _info| {
+                // println!("data_callback: date_out.len(): {}, info: {_info:?}.", data_out.len());
+
+                // TODO(Matej): can we use timestamps in _info instead?
+                // TODO(Matej): specify less strict ordering (in all places for this atomic var)
+                last_callback_timestamp_ns_alias.store(current_timestamp_ns(), Ordering::SeqCst);
+
+                data_out.iter_mut().for_each(|d| *d = mixer.next().unwrap_or(0f32))
+            },
+            |err| eprintln!("Got cpal stream error callback: {err}."),
+            None,
+        )?;
+
+        Ok(Self { mixer_controller, last_callback_timestamp_ns, _stream })
+    }
+
+    pub(crate) fn play<S: Source<Item = f32> + Send + 'static>(&self, source: S) {
+        let ns_since_last_callback = current_timestamp_ns()
+            .saturating_sub(self.last_callback_timestamp_ns.load(Ordering::SeqCst));
+        // println!("ns_since_last_callback: {ns_since_last_callback:>9}.",);
+
+        // We assume that cpal's audio callbacks come at a steady rate, so we delay sounds to play
+        // by the time since last audio callback, so that it gets played at correct offset during
+        // the *next* callback. This is needed to accurately position sounds (sub buffer level).
+        // https://github.com/tonarino/acoustic_profiler/issues/19#issuecomment-1522348735
+        self.mixer_controller.add(source.delay(Duration::from_nanos(ns_since_last_callback)));
+    }
+}
+
+fn current_timestamp_ns() -> u64 {
+    let duration_since_epoch =
+        SystemTime::now().duration_since(UNIX_EPOCH).expect("Unable to get current UNIX time");
+    duration_since_epoch
+        .as_nanos()
+        .try_into()
+        .expect("Cannot convert current UNIX timestamp in nanoseconds into u64")
+}


### PR DESCRIPTION
This is a form of alternative to #35 to resolve https://github.com/tonarino/acoustic_profiler/issues/19#issuecomment-1522348735

Note that this should resolve the specific problem, but we still may want to use `fundsp` (somehow) to synthetize and modify sound.

We still use `rodio` for audio file decoding and processing, but we drive the `cpal` audio callback directly (using code adapted from `rodio` itself).

That allows us to run custom code during the callback, which we use to offset samples tasked to play (giving all samples the same delay of one period, rather than variable delay based on how close next to the next callback they fire).

<details><summary>See example print of ns_since_last_callback when we play 1000 samples a second</summary> The period length is apparently ~42 ms.

```
ns_since_last_callback:  38695172.
ns_since_last_callback:  39784768.
ns_since_last_callback:  40887270.
ns_since_last_callback:  41945052.
ns_since_last_callback:    368139.
ns_since_last_callback:   1477218.
ns_since_last_callback:   2445557.
ns_since_last_callback:   3573154.
ns_since_last_callback:   4616437.
ns_since_last_callback:   5675630.
ns_since_last_callback:   6764239.
ns_since_last_callback:   7835255.
ns_since_last_callback:   8925809.
ns_since_last_callback:   9995435.
ns_since_last_callback:  11159180.
ns_since_last_callback:  12234090.
ns_since_last_callback:  13312871.
ns_since_last_callback:  14392252.
ns_since_last_callback:  15460542.
ns_since_last_callback:  16545115.
ns_since_last_callback:  17564547.
ns_since_last_callback:  18582770.
ns_since_last_callback:  19640031.
ns_since_last_callback:  20683684.
ns_since_last_callback:  21803771.
ns_since_last_callback:  22879984.
ns_since_last_callback:  23956644.
ns_since_last_callback:  25022856.
ns_since_last_callback:  26101435.
ns_since_last_callback:  27179575.
ns_since_last_callback:  28249203.
ns_since_last_callback:  29342603.
ns_since_last_callback:  30412447.
ns_since_last_callback:  31495496.
ns_since_last_callback:  32519447.
ns_since_last_callback:  33580415.
ns_since_last_callback:  34606142.
ns_since_last_callback:  35697450.
ns_since_last_callback:  36791844.
ns_since_last_callback:  37869512.
ns_since_last_callback:  38943775.
ns_since_last_callback:  40022488.
ns_since_last_callback:  41100993.
ns_since_last_callback:  42180112.
ns_since_last_callback:    481551.
ns_since_last_callback:   1608677.
ns_since_last_callback:   2667820.
ns_since_last_callback:   3745600.
ns_since_last_callback:   4785690.
```

</details>

With this I'm able to go from `tick_probe 1` all the way to `tick_probe 4000` (!) and still hear difference. [1]

[1] However, there seem to be inefficiencies somewhere that result in e.g. `composer` saying `Received 860 events (3440 bytes) in last 1.00s.` when we call `tick_probe 1000`. May be naive timing code in `tick_probe` itself (@PabloMansanet?).