### PR TITLE
Expand log probe to track individual logs

### DIFF
--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -20,8 +20,33 @@ pub enum Event {
     LogStats(LogStats),
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub enum LogStats {
+    Aggregate(AggregateLogStats),
+    Individual(IndividualLogStats),
+}
+
+/// Each log carries its own timestamp.
 #[derive(Serialize, Deserialize, Debug, Default)]
-pub struct LogStats {
+pub struct IndividualLogStats {
+    // We use duration since the UNIX epoch as a serializable timestamp.
+    pub logs: Vec<(Duration, LogLevel)>,
+}
+
+// FIXME: Duplicates the `log` crate definitions, but it's likely
+// still better than pulling the dependency.
+#[derive(Serialize, Deserialize, Debug)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+/// Logs are aggregated by type (better for very high frequency logging)
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct AggregateLogStats {
     // Duration covered by this report.
     pub span: Duration,
 

--- a/crates/log_probe/examples/warn_and_error_loop.rs
+++ b/crates/log_probe/examples/warn_and_error_loop.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 
 fn main() {
     log::set_boxed_logger(Box::new(
-        log_probe::LogProbe::new(None, Duration::from_millis(500)).unwrap(),
+        log_probe::LogProbe::new(None, Duration::from_millis(500), log_probe::Mode::Aggregated)
+            .unwrap(),
     ))
     .unwrap();
     log::set_max_level(log::LevelFilter::Trace);

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -1,4 +1,4 @@
-use composer_api::{self, Client, LogStats};
+use composer_api::{self, AggregateLogStats, Client, IndividualLogStats};
 use log::{self, Level};
 use std::{
     sync::{
@@ -6,7 +6,7 @@ use std::{
         mpsc::{sync_channel, Receiver, SyncSender},
         Arc,
     },
-    time::{Duration, Instant},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 use thiserror::Error;
 
@@ -32,10 +32,16 @@ enum AggregatorMessage {
     Tick,
 }
 
+pub enum Mode {
+    Aggregated,
+    Individual,
+}
+
 impl LogProbe {
     pub fn new(
         server_address: Option<String>,
         report_period: Duration,
+        mode: Mode,
     ) -> Result<Self, LogProbeError> {
         let shutdown = Arc::<AtomicBool>::default();
         let client = if let Some(address) = server_address {
@@ -46,7 +52,10 @@ impl LogProbe {
         .map_err(|e| LogProbeError::NetworkError(format!("{e}")))?;
 
         let (tx, rx) = sync_channel::<AggregatorMessage>(100);
-        spawn_aggregator_thread(rx, client, shutdown.clone());
+        match mode {
+            Mode::Aggregated => spawn_aggregated_mode_thread(rx, client, shutdown.clone()),
+            Mode::Individual => spawn_individual_mode_thread(rx, client, shutdown.clone()),
+        }
         spawn_tick_thread(tx.clone(), shutdown.clone(), report_period);
 
         Ok(Self { tx, shutdown })
@@ -74,12 +83,12 @@ fn spawn_tick_thread(
     });
 }
 
-fn spawn_aggregator_thread(
+fn spawn_aggregated_mode_thread(
     rx: Receiver<AggregatorMessage>,
     client: Client,
     shutdown: Arc<AtomicBool>,
 ) {
-    let mut log_stats = LogStats::default();
+    let mut log_stats = AggregateLogStats::default();
     let mut report_start = Instant::now();
 
     std::thread::spawn(move || {
@@ -89,10 +98,14 @@ fn spawn_aggregator_thread(
             }
 
             match message {
-                AggregatorMessage::AddRecord(record) => add_record(&mut log_stats, record),
+                AggregatorMessage::AddRecord(record) => {
+                    add_aggregate_record(&mut log_stats, record)
+                },
                 AggregatorMessage::Tick => {
                     log_stats.span = report_start.elapsed();
-                    if let Err(err) = client.send(&composer_api::Event::LogStats(log_stats)) {
+                    if let Err(err) = client.send(&composer_api::Event::LogStats(
+                        composer_api::LogStats::Aggregate(log_stats),
+                    )) {
                         eprintln!("Could not send event {:?}", err)
                     };
                     log_stats = Default::default();
@@ -103,7 +116,44 @@ fn spawn_aggregator_thread(
     });
 }
 
-fn add_record(log_stats: &mut LogStats, record_level: Level) {
+fn spawn_individual_mode_thread(
+    rx: Receiver<AggregatorMessage>,
+    client: Client,
+    shutdown: Arc<AtomicBool>,
+) {
+    let mut log_stats = IndividualLogStats::default();
+
+    std::thread::spawn(move || {
+        for message in rx {
+            if shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+
+            match message {
+                AggregatorMessage::AddRecord(record) => log_stats.logs.push((
+                    UNIX_EPOCH.elapsed().expect("Failed to calculate timestamp"),
+                    match record {
+                        Level::Error => composer_api::LogLevel::Error,
+                        Level::Warn => composer_api::LogLevel::Warn,
+                        Level::Info => composer_api::LogLevel::Info,
+                        Level::Debug => composer_api::LogLevel::Debug,
+                        Level::Trace => composer_api::LogLevel::Trace,
+                    },
+                )),
+                AggregatorMessage::Tick => {
+                    if let Err(err) = client.send(&composer_api::Event::LogStats(
+                        composer_api::LogStats::Individual(log_stats),
+                    )) {
+                        eprintln!("Could not send event {:?}", err)
+                    };
+                    log_stats = Default::default();
+                },
+            }
+        }
+    });
+}
+
+fn add_aggregate_record(log_stats: &mut AggregateLogStats, record_level: Level) {
     match record_level {
         Level::Error => log_stats.error_records += 1,
         Level::Warn => log_stats.warn_records += 1,


### PR DESCRIPTION
As discussed today on slack with @goodhoko; this expands the log probe to be able to report each individual timestamped log, but still send it in batches.