### PR TITLE
Support timed events

### DIFF
--- a/crates/composer/src/audio_output.rs
+++ b/crates/composer/src/audio_output.rs
@@ -67,12 +67,10 @@ impl AudioOutput {
         Ok(Self { source_tx, play_delay, too_early_plays, _stream })
     }
 
-    pub(crate) fn play<S: Source<Item = f32> + Send + 'static>(
-        &self,
-        source: S,
-        timestamp: Duration,
-    ) {
-        // TODO(Matej): use timestamp from the event itself once we have it.
+    pub(crate) fn play<S>(&self, source: S, timestamp: Duration)
+    where
+        S: Source<Item = f32> + Send + 'static,
+    {
         let play_at_timestamp = timestamp + self.play_delay;
 
         // TODO(Matej): we are in fact double-boxing because DynamicMixerController internally adds

--- a/crates/composer/src/jukebox.rs
+++ b/crates/composer/src/jukebox.rs
@@ -4,6 +4,7 @@ use rodio::{
     source::{Buffered, SamplesConverter},
     Decoder, Source,
 };
+use std::time::Duration;
 use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -49,12 +50,12 @@ impl Jukebox {
         Ok(Self { samples })
     }
 
-    pub(crate) fn play(&self, audio_output: &AudioOutput, sample: Sample) {
+    pub(crate) fn play(&self, audio_output: &AudioOutput, sample: Sample, timestamp: Duration) {
         let buffer = self
             .samples
             .get(&sample)
             .expect("programmer error, all possible samples should be loaded");
 
-        audio_output.play(buffer.clone());
+        audio_output.play(buffer.clone(), timestamp);
     }
 }

--- a/crates/composer/src/jukebox.rs
+++ b/crates/composer/src/jukebox.rs
@@ -4,8 +4,7 @@ use rodio::{
     source::{Buffered, SamplesConverter},
     Decoder, Source,
 };
-use std::time::Duration;
-use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
+use std::{collections::HashMap, fs::File, io::BufReader, path::Path, time::Duration};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum Sample {

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -1,9 +1,9 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
-use crate::util::current_timestamp;
 use crate::{
     audio_output::AudioOutput,
     jukebox::{Jukebox, Sample},
+    util::current_timestamp,
 };
 use clap::Parser;
 use composer_api::{EventKind, EventMessage, DEFAULT_SERVER_ADDRESS};

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -6,7 +6,7 @@ use crate::{
     util::current_timestamp,
 };
 use clap::Parser;
-use composer_api::{EventKind, EventMessage, DEFAULT_SERVER_ADDRESS};
+use composer_api::{EventKind, Packet, DEFAULT_SERVER_ADDRESS};
 use eyre::{Context, Result};
 use std::{
     net::UdpSocket,
@@ -59,9 +59,9 @@ fn handle_datagram(
     let mut buf = [0; 1500];
     let (number_of_bytes, _) = socket.recv_from(&mut buf)?;
 
-    let message: EventMessage = bincode::deserialize(&buf[..number_of_bytes])?;
+    let packet: Packet = bincode::deserialize(&buf[..number_of_bytes])?;
 
-    for event in message.events {
+    for event in packet.events {
         let sample = match event.kind {
             EventKind::TestTick => Sample::Clack,
 

--- a/crates/composer/src/main.rs
+++ b/crates/composer/src/main.rs
@@ -71,6 +71,7 @@ fn handle_datagram(
             | EventKind::FileSystemWrite
             | EventKind::FileSystemRead => Sample::Click,
             // TODO(Pablo): Play a sound that scales with the number of reports.
+            EventKind::Log { level: _ } => todo!(),
             EventKind::LogStats(_) => todo!(),
         };
         let timestamp = event.timestamp.unwrap_or_else(current_timestamp);

--- a/crates/composer/src/util.rs
+++ b/crates/composer/src/util.rs
@@ -1,0 +1,6 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Get current timestamp as the `Duration` since the UNIX epoch.
+pub(crate) fn current_timestamp() -> Duration {
+    SystemTime::now().duration_since(UNIX_EPOCH).expect("Unable to get current UNIX time")
+}

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -48,6 +48,11 @@ impl Event {
         Self { kind, timestamp }
     }
 
+    pub fn with_current_timestamp(kind: EventKind) -> Self {
+        let timestamp = Some(UNIX_EPOCH.elapsed().expect("Failed to calculate timestamp"));
+        Self { kind, timestamp }
+    }
+
     pub fn with_timestamp(kind: EventKind, timestamp: Duration) -> Self {
         let timestamp = Some(timestamp);
         Self { kind, timestamp }

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -26,6 +26,11 @@ impl EventMessage {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn with_event(event: Event) -> Self {
+        let events = vec![event];
+        Self { events }
+    }
 }
 
 impl Default for EventMessage {

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -12,30 +12,23 @@ use std::{
 
 pub const DEFAULT_SERVER_ADDRESS: &str = "localhost:8888";
 
-/// Composer expects `EventMessage` as the incoming probe data.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct EventMessage {
+/// Composer expects `Packet` as the incoming probe data.
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Packet {
     /// List of events a probe collected during a specific time window. For a probe generating
     /// high-frequency events e.g. more than a hundred per second, it's recommended to buffer and
-    /// pack multiple events into a `EventMessage` to avoid overflowing the socket and reduce
+    /// pack multiple events into a `Packet` to avoid overflowing the socket and reduce
     /// packet overhead.
     pub events: Vec<Event>,
 }
 
-impl EventMessage {
+impl Packet {
     pub fn new(events: Vec<Event>) -> Self {
         Self { events }
     }
 
-    pub fn with_event(event: Event) -> Self {
+    pub fn from_event(event: Event) -> Self {
         let events = vec![event];
-        Self { events }
-    }
-}
-
-impl Default for EventMessage {
-    fn default() -> Self {
-        let events = Vec::default();
         Self { events }
     }
 }
@@ -125,8 +118,8 @@ impl Client {
         Ok(Self { socket })
     }
 
-    pub fn send(&self, message: &EventMessage) -> Result<()> {
-        let data = bincode::serialize(message)?;
+    pub fn send(&self, packet: &Packet) -> Result<()> {
+        let data = bincode::serialize(packet)?;
         self.socket.send(&data)?;
         Ok(())
     }

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
         SocketAddr::{V4, V6},
         ToSocketAddrs, UdpSocket,
     },
-    time::Duration,
+    time::{Duration, UNIX_EPOCH},
 };
 
 pub const DEFAULT_SERVER_ADDRESS: &str = "localhost:8888";

--- a/crates/composer_api/src/lib.rs
+++ b/crates/composer_api/src/lib.rs
@@ -23,8 +23,8 @@ pub struct EventMessage {
 }
 
 impl EventMessage {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(events: Vec<Event>) -> Self {
+        Self { events }
     }
 
     pub fn with_event(event: Event) -> Self {
@@ -76,21 +76,12 @@ pub enum EventKind {
     FileSystemRead,
     /// A write() syscall invocation to a file other than stdout/stderr.
     FileSystemWrite,
+    /// A log() invocation at a specified severity level.
+    Log {
+        level: LogLevel,
+    },
     /// Logging events for a specific duration.
     LogStats(LogStats),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum LogStats {
-    Aggregate(AggregateLogStats),
-    Individual(IndividualLogStats),
-}
-
-/// Each log carries its own timestamp.
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct IndividualLogStats {
-    // We use duration since the UNIX epoch as a serializable timestamp.
-    pub logs: Vec<(Duration, LogLevel)>,
 }
 
 // FIXME: Duplicates the `log` crate definitions, but it's likely
@@ -106,7 +97,7 @@ pub enum LogLevel {
 
 /// Logs are aggregated by type (better for very high frequency logging)
 #[derive(Serialize, Deserialize, Debug, Default)]
-pub struct AggregateLogStats {
+pub struct LogStats {
     // Duration covered by this report.
     pub span: Duration,
 

--- a/crates/dtrace_probe/src/main.rs
+++ b/crates/dtrace_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event, EventKind, EventMessage};
+use composer_api::{Client, Event, EventKind, Packet};
 use dtrace::{DTrace, ProgramStatus};
 use eyre::Result;
 
@@ -53,8 +53,8 @@ fn main() -> Result<()> {
                 _ => continue,
             };
 
-            let message = EventMessage::with_event(Event::new(kind));
-            if let Err(err) = client.send(&message) {
+            let packet = Packet::from_event(Event::new(kind));
+            if let Err(err) = client.send(&packet) {
                 eprintln!("Could not send event {:?}", err)
             };
         }

--- a/crates/dtrace_probe/src/main.rs
+++ b/crates/dtrace_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event};
+use composer_api::{Client, Event, EventKind, EventMessage};
 use dtrace::{DTrace, ProgramStatus};
 use eyre::Result;
 
@@ -43,17 +43,18 @@ fn main() -> Result<()> {
             let _timestamp: u128 = probe.traces[0].parse()?;
             let arg0 = &probe.traces[1];
 
-            let event = match probe.function_name.as_str() {
-                "read" | "read_nocancel" => Event::FileSystemRead,
+            let kind = match probe.function_name.as_str() {
+                "read" | "read_nocancel" => EventKind::FileSystemRead,
                 "write" | "write_nocancel" => match arg0.as_str() {
-                    "1" => Event::StdoutWrite { length: 0 },
-                    "2" => Event::StderrWrite { length: 0 },
-                    _ => Event::FileSystemWrite,
+                    "1" => EventKind::StdoutWrite { length: 0 },
+                    "2" => EventKind::StderrWrite { length: 0 },
+                    _ => EventKind::FileSystemWrite,
                 },
                 _ => continue,
             };
 
-            if let Err(err) = client.send(&event) {
+            let message = EventMessage::with_event(Event::new(kind));
+            if let Err(err) = client.send(&message) {
                 eprintln!("Could not send event {:?}", err)
             };
         }

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -1,4 +1,6 @@
-use composer_api::{self, AggregateLogStats, Client, IndividualLogStats};
+use composer_api::{
+    self, AggregateLogStats, Client, Event, EventKind, EventMessage, IndividualLogStats, LogStats,
+};
 use log::{self, Level};
 use std::{
     sync::{
@@ -103,11 +105,11 @@ fn spawn_aggregated_mode_thread(
                 },
                 AggregatorMessage::Tick => {
                     log_stats.span = report_start.elapsed();
-                    if let Err(err) = client.send(&composer_api::Event::LogStats(
-                        composer_api::LogStats::Aggregate(log_stats),
-                    )) {
+                    let event = Event::new(EventKind::LogStats(LogStats::Aggregate(log_stats)));
+                    let message = EventMessage::with_event(event);
+                    if let Err(err) = client.send(&message) {
                         eprintln!("Could not send event {:?}", err)
-                    };
+                    }
                     log_stats = Default::default();
                     report_start = Instant::now();
                 },
@@ -141,9 +143,9 @@ fn spawn_individual_mode_thread(
                     },
                 )),
                 AggregatorMessage::Tick => {
-                    if let Err(err) = client.send(&composer_api::Event::LogStats(
-                        composer_api::LogStats::Individual(log_stats),
-                    )) {
+                    let event = Event::new(EventKind::LogStats(LogStats::Individual(log_stats)));
+                    let message = EventMessage::with_event(event);
+                    if let Err(err) = client.send(&message) {
                         eprintln!("Could not send event {:?}", err)
                     };
                     log_stats = Default::default();

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -1,4 +1,4 @@
-use composer_api::{self, Client, Event, EventKind, EventMessage, LogStats};
+use composer_api::{self, Client, Event, EventKind, LogStats, Packet};
 use log::{self, Level};
 use std::{
     sync::{
@@ -104,7 +104,7 @@ fn spawn_aggregated_mode_thread(
                 AggregatorMessage::Tick => {
                     log_stats.span = report_start.elapsed();
                     let event = Event::new(EventKind::LogStats(log_stats));
-                    if let Err(err) = client.send(&EventMessage::with_event(event)) {
+                    if let Err(err) = client.send(&Packet::from_event(event)) {
                         eprintln!("Could not send event {:?}", err)
                     }
                     log_stats = Default::default();
@@ -144,7 +144,7 @@ fn spawn_individual_mode_thread(
                     events.push(event);
                 },
                 AggregatorMessage::Tick => {
-                    if let Err(err) = client.send(&EventMessage::new(events)) {
+                    if let Err(err) = client.send(&Packet::new(events)) {
                         eprintln!("Could not send event {:?}", err)
                     };
                     events = Vec::new();

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -137,10 +137,7 @@ fn spawn_individual_mode_thread(
                         Level::Debug => composer_api::LogLevel::Debug,
                         Level::Trace => composer_api::LogLevel::Trace,
                     };
-                    let event = Event::with_timestamp(
-                        EventKind::Log { level },
-                        UNIX_EPOCH.elapsed().expect("Failed to calculate timestamp"),
-                    );
+                    let event = Event::with_current_timestamp(EventKind::Log { level });
                     events.push(event);
                 },
                 AggregatorMessage::Tick => {

--- a/crates/log_probe/src/lib.rs
+++ b/crates/log_probe/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
         mpsc::{sync_channel, Receiver, SyncSender},
         Arc,
     },
-    time::{Duration, Instant, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 use thiserror::Error;
 

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event, EventKind, EventMessage};
+use composer_api::{Client, Event, EventKind, Packet};
 use eyre::Result;
 use nix::{
     sys::{ptrace, wait::waitpid},
@@ -31,8 +31,8 @@ fn main() -> Result<()> {
     waitpid(Some(pid), None)?;
     loop {
         let Some(event) = handle_syscall(pid)? else { continue; };
-        let message = EventMessage::with_event(event);
-        if let Err(err) = client.send(&message) {
+        let packet = Packet::from_event(event);
+        if let Err(err) = client.send(&packet) {
             eprintln!("Could not send event {:?}", err)
         };
     }

--- a/crates/ptrace_probe/src/main.rs
+++ b/crates/ptrace_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event};
+use composer_api::{Client, Event, EventKind, EventMessage};
 use eyre::Result;
 use nix::{
     sys::{ptrace, wait::waitpid},
@@ -31,7 +31,8 @@ fn main() -> Result<()> {
     waitpid(Some(pid), None)?;
     loop {
         let Some(event) = handle_syscall(pid)? else { continue; };
-        if let Err(err) = client.send(&event) {
+        let message = EventMessage::with_event(event);
+        if let Err(err) = client.send(&message) {
             eprintln!("Could not send event {:?}", err)
         };
     }
@@ -51,10 +52,12 @@ fn handle_syscall(pid: Pid) -> Result<Option<Event>, color_eyre::Report> {
 
     match (syscall, rdi) {
         (Sysno::write, 1) => {
-            Ok(Some(Event::StdoutWrite { length: ptrace::getregs(pid)?.rax as usize }))
+            let length = ptrace::getregs(pid)?.rax as usize;
+            Ok(Some(Event::new(EventKind::StdoutWrite { length })))
         },
         (Sysno::write, 2) => {
-            Ok(Some(Event::StderrWrite { length: ptrace::getregs(pid)?.rax as usize }))
+            let length = ptrace::getregs(pid)?.rax as usize;
+            Ok(Some(Event::new(EventKind::StderrWrite { length })))
         },
         _ => Ok(None),
     }

--- a/crates/test_probe/src/main.rs
+++ b/crates/test_probe/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
 use clap::Parser;
-use composer_api::{Client, Event};
+use composer_api::{Client, Event, EventKind, EventMessage};
 use eyre::Result;
 use std::{thread, time::Duration};
 
@@ -21,7 +21,8 @@ fn main() -> Result<()> {
         None => Client::try_default(),
     }?;
 
-    let event = Event::TestTick;
+    let event = Event::new(EventKind::TestTick);
+    let message = EventMessage::with_event(event);
 
     // u64 taken by `from_millis` doesn't implement DoubleEndedIterator needed by `rev`
     // Use u32 explicitly and convert to u64.
@@ -29,7 +30,7 @@ fn main() -> Result<()> {
     let speedup = slowdown.clone().rev();
 
     for delay_ms in speedup.chain(slowdown).cycle() {
-        if let Err(err) = client.send(&event) {
+        if let Err(err) = client.send(&message) {
             eprintln!("Could not send event {:?}", err)
         };
         thread::sleep(Duration::from_millis(delay_ms.into()));

--- a/crates/test_probe/src/main.rs
+++ b/crates/test_probe/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 
 use clap::Parser;
-use composer_api::{Client, Event, EventKind, EventMessage};
+use composer_api::{Client, Event, EventKind, Packet};
 use eyre::Result;
 use std::{thread, time::Duration};
 
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     }?;
 
     let event = Event::new(EventKind::TestTick);
-    let message = EventMessage::with_event(event);
+    let packet = Packet::from_event(event);
 
     // u64 taken by `from_millis` doesn't implement DoubleEndedIterator needed by `rev`
     // Use u32 explicitly and convert to u64.
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let speedup = slowdown.clone().rev();
 
     for delay_ms in speedup.chain(slowdown).cycle() {
-        if let Err(err) = client.send(&message) {
+        if let Err(err) = client.send(&packet) {
             eprintln!("Could not send event {:?}", err)
         };
         thread::sleep(Duration::from_millis(delay_ms.into()));

--- a/crates/tick_probe/src/main.rs
+++ b/crates/tick_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event, EventKind, EventMessage};
+use composer_api::{Client, Event, EventKind, Packet};
 use eyre::Result;
 use std::time::{Duration, Instant};
 
@@ -23,12 +23,12 @@ fn main() -> Result<()> {
     }?;
 
     let event = Event::new(EventKind::TestTick);
-    let message = EventMessage::with_event(event);
+    let packet = Packet::from_event(event);
 
     // Try to prevent drifting away from the given frequency by dynamically computing the sleep duration for each cycle
     let start = Instant::now();
     for deadline in (0..).map(|i| start + Duration::from_secs_f64(i as f64 / args.frequency)) {
-        if let Err(err) = client.send(&message) {
+        if let Err(err) = client.send(&packet) {
             eprintln!("Could not send event {:?}", err)
         };
 

--- a/crates/tick_probe/src/main.rs
+++ b/crates/tick_probe/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use composer_api::{Client, Event};
+use composer_api::{Client, Event, EventKind, EventMessage};
 use eyre::Result;
 use std::time::{Duration, Instant};
 
@@ -22,12 +22,13 @@ fn main() -> Result<()> {
         None => Client::try_default(),
     }?;
 
-    let event = Event::TestTick;
+    let event = Event::new(EventKind::TestTick);
+    let message = EventMessage::with_event(event);
 
     // Try to prevent drifting away from the given frequency by dynamically computing the sleep duration for each cycle
     let start = Instant::now();
     for deadline in (0..).map(|i| start + Duration::from_secs_f64(i as f64 / args.frequency)) {
-        if let Err(err) = client.send(&event) {
+        if let Err(err) = client.send(&message) {
             eprintln!("Could not send event {:?}", err)
         };
 


### PR DESCRIPTION
This PR supports sending multiple, timestamped events as a general composer API.

* Support optional timestamp for each event
* Support sending multiple events in a UDP packet
* Simplify `log_probe` using the new `Event` and `EventMessage` structs