### PR TITLE
Support timed events for dtrace + other improvements

### DIFF
--- a/crates/dtrace_probe/Cargo.toml
+++ b/crates/dtrace_probe/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 color-eyre = "0.6"
 clap = { version = "4.2", features = ["derive"] }
 composer_api = { path = "../composer_api" }
+ctrlc = { version = "3.2", features = ["termination"] }
 dtrace = { path = "../dtrace" }
 eyre = "0.6"

--- a/crates/dtrace_probe/src/main.rs
+++ b/crates/dtrace_probe/src/main.rs
@@ -2,9 +2,13 @@ use clap::Parser;
 use composer_api::{Client, Event, EventKind, Packet};
 use dtrace::{DTrace, ProgramStatus};
 use eyre::Result;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/crates/dtrace_probe/src/main.rs
+++ b/crates/dtrace_probe/src/main.rs
@@ -2,6 +2,9 @@ use clap::Parser;
 use composer_api::{Client, Event, EventKind, Packet};
 use dtrace::{DTrace, ProgramStatus};
 use eyre::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -10,13 +13,22 @@ struct Args {
     server_address: Option<String>,
 
     #[structopt(short, long)]
-    process_id: u32,
+    process_id: Option<u32>,
 }
 
 fn main() -> Result<()> {
     color_eyre::install()?;
 
     let args = Args::parse();
+
+    let running = Arc::new(AtomicBool::new(true));
+    ctrlc::set_handler({
+        let running = running.clone();
+        move || {
+            running.store(false, Ordering::SeqCst);
+        }
+    })
+    .expect("Failed to set Ctrl-C handler");
 
     let client = match args.server_address {
         Some(address) => Client::new(address)?,
@@ -28,19 +40,22 @@ fn main() -> Result<()> {
     // We need to set the bufsize option explicitly; otherwise we get "Enabling exceeds size of
     // buffer" error.
     let options = &[("bufsize", "4m")];
-    let pid = args.process_id;
+    let predicate =
+        args.process_id.map(|pid| format!("/pid == {pid}/")).unwrap_or_else(|| "".to_string());
     dtrace.execute_program(
         &format!(
-            "syscall:::entry /pid == {pid}/ {{ trace(walltimestamp); trace(arg0); trace(arg1); }}"
+            "syscall:::entry {predicate} {{ trace(walltimestamp); trace(arg0); trace(arg1); }}"
         ),
         options,
     )?;
 
-    loop {
+    while running.load(Ordering::SeqCst) {
+        let mut packet = Packet::default();
+
         let result = dtrace.wait_and_consume()?;
+
         for probe in &result.probes {
-            // TODO(skywhale): Use this timestamp.
-            let _timestamp: u128 = probe.traces[0].parse()?;
+            let timestamp = Duration::from_nanos(probe.traces[0].parse().expect("Failed to parse timestamp"));
             let arg0 = &probe.traces[1];
 
             let kind = match probe.function_name.as_str() {
@@ -53,7 +68,10 @@ fn main() -> Result<()> {
                 _ => continue,
             };
 
-            let packet = Packet::from_event(Event::new(kind));
+            let event = Event::with_timestamp(kind, timestamp);
+            packet.events.push(event);
+        }
+        if !packet.events.is_empty() {
             if let Err(err) = client.send(&packet) {
                 eprintln!("Could not send event {:?}", err)
             };

--- a/crates/dtrace_probe/src/main.rs
+++ b/crates/dtrace_probe/src/main.rs
@@ -55,7 +55,8 @@ fn main() -> Result<()> {
         let result = dtrace.wait_and_consume()?;
 
         for probe in &result.probes {
-            let timestamp = Duration::from_nanos(probe.traces[0].parse().expect("Failed to parse timestamp"));
+            let timestamp =
+                Duration::from_nanos(probe.traces[0].parse().expect("Failed to parse timestamp"));
             let arg0 = &probe.traces[1];
 
             let kind = match probe.function_name.as_str() {


### PR DESCRIPTION
* Send multiple, timestamped events in `EventMessage`
* Add a proper ctrl-c handling to prevent kernel crash in rare circumstances
* Make the process ID argument an optional, to probe the entire kernel